### PR TITLE
Enable vpn

### DIFF
--- a/vcluster-use-cases/auto-nodes-aws/manifests/auto-nodes-aws-template.yaml
+++ b/vcluster-use-cases/auto-nodes-aws/manifests/auto-nodes-aws-template.yaml
@@ -103,6 +103,8 @@ spec:
                     tag: '{{ .Values.k8sVersion }}'
             privateNodes:
               enabled: true
+              vpn:
+                enabled: true
               autoNodes:
                 - provider: aws-ec2-node-provider
                   dynamic:


### PR DESCRIPTION
Without vpn enabled the nodes in ec2 cannot connect to the controlplane on boot.